### PR TITLE
Configure for fdroid

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
+        maven { url "https://jitpack.io" }
         jcenter()
         google()
     }
@@ -11,6 +12,7 @@ buildscript {
 
 allprojects {
     repositories {
+        maven { url "https://jitpack.io" }
         jcenter()
         google()
         mavenCentral()

--- a/guidepost/build.gradle
+++ b/guidepost/build.gradle
@@ -42,12 +42,11 @@ android {
 }
 
 dependencies {
-//    implementation files('libs/commons-io-2.4.jar')
     implementation files('libs/httpclient-4.3.6.jar')
     implementation files('libs/httpcore-4.3.3.jar')
     implementation files('libs/httpmime-4.3.6.jar')
-    implementation files('libs/urlimageviewhelper-1.0.4.jar')
-    implementation files('libs/osmbonuspack_6.6.0.aar')
+    implementation 'com.koushikdutta.urlimageviewhelper:urlimageviewhelper:1.0.4'
+    implementation 'com.github.MKergall:osmbonuspack:6.6.0'
     implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.android.support:design:28.0.0'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'

--- a/org.walley.guidepost.yml
+++ b/org.walley.guidepost.yml
@@ -1,0 +1,52 @@
+License: Unknown
+SourceCode: https://github.com/vanous/guidepost.git
+IssueTracker: https://github.com/vanous/guidepost.git/issues
+
+RepoType: git
+Repo: https://github.com/vanous/guidepost.git
+
+Builds:
+  - versionName: '1.20'
+    versionCode: '23'
+    commit: set_tag_here
+    subdir: guidepost
+    gradle:
+      - yes
+    srclibs:
+      - CommonsIO@2.4
+      - ApacheHttpCore@4.3.3
+      - ApacheHttpClient@4.3.6
+    prebuild:
+      - rm libs/*
+        #- mkdir libs
+        #- pwd
+        #- cp ../../build.gradle ./
+        #- cp ../../build.gradle.project ../build.gradle
+        #- sed -i -e '/slf4j-android/d' $$OSMBonusPack$$/build.gradle
+        #- cp -r $$OSMBonusPack$$ ../
+        #- gradle build
+      - pushd $$CommonsIO$$
+      - $$MVN3$$ package -Dmaven.test.skip=true
+      - popd
+      - cp $$CommonsIO$$/target/commons-io-2.4.jar libs/
+      - pushd $$ApacheHttpClient$$/httpclient/
+      - sed -i -e 's/<packaging>jar<\/packaging>/<packaging>jar<\/packaging><properties> <maven.compiler.source>1.6<\/maven.compiler.source> <maven.compiler.target>1.6<\/maven.compiler.target> <\/properties>/g' pom.xml
+      - $$MVN3$$ package -Dmaven.test.skip=true -Dmaven.javadoc.skip=true
+        #- $$MVN3$$ package
+      - popd
+      - cp $$ApacheHttpClient$$/httpclient/target/httpclient-4.3.6.jar libs/
+      - pushd $$ApacheHttpCore$$/httpcore
+      - sed -i -e 's/<packaging>jar<\/packaging>/<packaging>jar<\/packaging><properties> <maven.compiler.source>1.6<\/maven.compiler.source> <maven.compiler.target>1.6<\/maven.compiler.target> <\/properties>/g' pom.xml
+      - $$MVN3$$ package -Dmaven.test.skip=true -Dmaven.javadoc.skip=true
+      - popd
+      - cp $$ApacheHttpCore$$/httpcore/target/httpcore-4.3.3.jar libs/
+      - pushd $$ApacheHttpClient$$/httpmime/
+      - sed -i -e 's/<packaging>jar<\/packaging>/<packaging>jar<\/packaging><properties> <maven.compiler.source>1.6<\/maven.compiler.source> <maven.compiler.target>1.6<\/maven.compiler.target> <\/properties>/g' pom.xml
+      - $$MVN3$$ package -Dmaven.test.skip=true -Dmaven.javadoc.skip=true
+        #- $$MVN3$$ package
+      - popd
+      - cp $$ApacheHttpClient$$/httpmime/target/httpmime-4.3.6.jar libs/
+
+
+AutoUpdateMode: None
+UpdateCheckMode: Tags


### PR DESCRIPTION
Ahoj,

toto upravuje gradle.builds tak, aby bylo buildovatelené pomocí fdroidu s přiloženám yml souborem, ve kterém je pak nutno nastavit aktuální tag, pod kterým je tento commit k dispozici.

Pak je potřeba pokračovat dále (jen pár blbostí - licence, ikonyy atd, to klidně pak udělám, teď jsem si to odzkoušel tady ( https://github.com/vanous/BlitzTypeKeyboard s tímto metadata souborem https://gitlab.com/fdroid/fdroiddata/merge_requests/5348 , zatím čekám na review...).

builduje se to OK jak pod fdroid tak s ./gradlew

ten urlimageview bych tam zatím klidně nechal a až to bude převedeno na ion, upravíme build script...